### PR TITLE
Add default.env

### DIFF
--- a/scripts/helper_functions.sh
+++ b/scripts/helper_functions.sh
@@ -48,6 +48,8 @@ get_branch_config_path() {
     local environment_name=$(echo "$CI_COMMIT_REF_NAME" | sed -E 's/(.+)-[0-9x]+\.[0-9]+\.[0-9]+/\1/')
     if [ -f "$CI_PROJECT_DIR/ci-branch-config/$environment_name.env" ]; then
       echo ci-branch-config/"$environment_name.env"
+    elif [ -f "$CI_PROJECT_DIR/ci-branch-config/default.env" ]; then
+      echo ci-branch-config/default.env
     fi
   fi
 }


### PR DESCRIPTION
Currently branch config variables have the highest priority. No matter what I set in group, project, yaml, UI... branch config rewrites everything.

This is a problem when I want to define some default values for specific branches but I need the possibility the overwrite them for example in UI when running pipeline manually. That's why I started to use this smart bash notation in `.env` files
```
ENVIRONMENT="${ENVIRONMENT:-Development}"
```
This says "if ENVIRONMENT is not empty, use it, otherwise use Development". This gives the lowest possible priority to branch config variables (now everything is stronger, branch config is used only if it's not defined anywhere else) which seems much more useful to me. Anyway with this approach it's just up to me which way I want to use in my project, it does not affect anyone else, which is great. But... 😩 

...approach to `common.env` breaks this whole idea. I need some default values for non explicitly defined branches, which I use `common.env` for. But then `ENVIRONMENT` is defined from common.env on all branches and it's never overwritten on explicit ones. I'd like to have something like common.env but after explicit branch config is evaluated. I mean failover when there is nothing defined above, use this.

My idea is to add `default.env`. It's non breaking change, it does not affect anyone and it can be very useful. Thoughts?