### PR TITLE
🐛 Remove read_branch_config from get_image_name - we use dotenv funct…

### DIFF
--- a/scripts/helper_functions.sh
+++ b/scripts/helper_functions.sh
@@ -63,7 +63,6 @@ read_branch_config() {
 # we can't do this in `variables:`, because branch configuration
 # is loaded after resolving `$GCP_PROJECT_ID` variable
 get_image_name() {
-  read_branch_config
   echo "$DOCKER_REGISTRY_URL/$GCP_PROJECT_ID/$CI_PROJECT_NAME"
 }
 


### PR DESCRIPTION
…ionality in Gitlab CI

Related: #67681